### PR TITLE
Show only items with status 0

### DIFF
--- a/client/src/app/storage.service.ts
+++ b/client/src/app/storage.service.ts
@@ -20,7 +20,9 @@ export class StorageService {
     private msg: NotificationService
   ) {
     this.tags = JSON.parse(localStorage.getItem("pocket-tags"));
-    this.list = JSON.parse(localStorage.getItem("pocket-list"));
+    this.list = JSON.parse(localStorage.getItem("pocket-list")).filter(function (e) {
+      return e.status !== '1';
+    });
   }
 
   getItem$(): Observable<Item[]> {

--- a/client/src/app/storage.service.ts
+++ b/client/src/app/storage.service.ts
@@ -21,7 +21,7 @@ export class StorageService {
   ) {
     this.tags = JSON.parse(localStorage.getItem("pocket-tags"));
     this.list = JSON.parse(localStorage.getItem("pocket-list")).filter(function (e) {
-      return e.status !== '1';
+      return e.status === '0';
     });
   }
 


### PR DESCRIPTION
According to the API https://getpocket.com/developer/docs/v3/retrieve `status === 1` is 'archived' and `status === 2` is 'should be deleted' so there is no reason to show those items. I am seeing many links that I have already read or deleted, this shows only what I have not seen yet.